### PR TITLE
Use innerHTML instead of outerHTML. See below:

### DIFF
--- a/dist/amd/aurelia-ssr-engine.js
+++ b/dist/amd/aurelia-ssr-engine.js
@@ -23,7 +23,7 @@ define(["require", "exports", "./transformers", "./cleanup", "./reflect", "./pro
             .then(function (ctx) {
             var document = ctx.pal.DOM.global.document;
             setInputDefaultValues(document.body);
-            var html = transformers_1.transform({ app: ctx.aurelia.host.outerHTML, document: document }, options);
+            var html = transformers_1.transform({ app: ctx.aurelia.host.innerHTML, document: document }, options);
             ctx.stop();
             cleanup_1.cleanup(options);
             return html;

--- a/dist/amd/interfaces.d.ts
+++ b/dist/amd/interfaces.d.ts
@@ -23,6 +23,10 @@ export interface RenderOptions {
      */
     replayDelay?: number;
     /**
+     * When using preboot, where can the preboot script be found
+     */
+    prebootScript?: string;
+    /**
      * Options that are passed to preboot
      */
     prebootOptions?: any;

--- a/dist/amd/transformers/preboot.js
+++ b/dist/amd/transformers/preboot.js
@@ -6,6 +6,9 @@ define(["require", "exports", "preboot", "./utils"], function (require, exports,
             if (options.replayDelay === undefined) {
                 options.replayDelay = 10;
             }
+            if (options.prebootScript === undefined) {
+                options.prebootScript = "preboot_browser.js";
+            }
             // preboot catches all events that happens before Aurelia gets loaded client-side
             // so that they can be replayed afterwards
             var prebootOptions = Object.assign({
@@ -27,7 +30,7 @@ define(["require", "exports", "preboot", "./utils"], function (require, exports,
             var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
             html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
             // preboot_browser can replay events that were stored by the preboot code
-            var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+            var script = "\r\n<script src=\"" + options.prebootScript + "\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
             if (html.indexOf("<!-- preboot_script -->") !== -1) {
                 html = html.replace("<!-- preboot_script -->", script);
             }

--- a/dist/amd/transformers/preboot.js
+++ b/dist/amd/transformers/preboot.js
@@ -27,7 +27,13 @@ define(["require", "exports", "preboot", "./utils"], function (require, exports,
             var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
             html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
             // preboot_browser can replay events that were stored by the preboot code
-            html = utils_1.appendToBody(html, "\r\n<script src=\"preboot_browser.js\"></script>\n      <script>\n      document.addEventListener('aurelia-started', function () {\n        // Aurelia has started client-side\n        // but the view/view-model hasn't been loaded yet so we need a small\n        // delay until we can playback all events.\n        setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n      });\n      </script>");
+            var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+            if (html.indexOf("<!-- preboot_script -->") !== -1) {
+                html = html.replace("<!-- preboot_script -->", script);
+            }
+            else {
+                html = utils_1.appendToBody(html, script);
+            }
         }
         return html;
     }

--- a/dist/commonjs/aurelia-ssr-engine.js
+++ b/dist/commonjs/aurelia-ssr-engine.js
@@ -26,7 +26,7 @@ function render(options, initOptions) {
         .then(function (ctx) {
         var document = ctx.pal.DOM.global.document;
         setInputDefaultValues(document.body);
-        var html = transformers_1.transform({ app: ctx.aurelia.host.outerHTML, document: document }, options);
+        var html = transformers_1.transform({ app: ctx.aurelia.host.innerHTML, document: document }, options);
         ctx.stop();
         cleanup_1.cleanup(options);
         return html;

--- a/dist/commonjs/interfaces.d.ts
+++ b/dist/commonjs/interfaces.d.ts
@@ -23,6 +23,10 @@ export interface RenderOptions {
      */
     replayDelay?: number;
     /**
+     * When using preboot, where can the preboot script be found
+     */
+    prebootScript?: string;
+    /**
      * Options that are passed to preboot
      */
     prebootOptions?: any;

--- a/dist/commonjs/transformers/preboot.js
+++ b/dist/commonjs/transformers/preboot.js
@@ -7,6 +7,9 @@ function default_1(html, transformerCtx, options) {
         if (options.replayDelay === undefined) {
             options.replayDelay = 10;
         }
+        if (options.prebootScript === undefined) {
+            options.prebootScript = "preboot_browser.js";
+        }
         // preboot catches all events that happens before Aurelia gets loaded client-side
         // so that they can be replayed afterwards
         var prebootOptions = Object.assign({
@@ -28,7 +31,7 @@ function default_1(html, transformerCtx, options) {
         var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
         // preboot_browser can replay events that were stored by the preboot code
-        var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+        var script = "\r\n<script src=\"" + options.prebootScript + "\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
         if (html.indexOf("<!-- preboot_script -->") !== -1) {
             html = html.replace("<!-- preboot_script -->", script);
         }

--- a/dist/commonjs/transformers/preboot.js
+++ b/dist/commonjs/transformers/preboot.js
@@ -28,7 +28,13 @@ function default_1(html, transformerCtx, options) {
         var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
         // preboot_browser can replay events that were stored by the preboot code
-        html = utils_1.appendToBody(html, "\r\n<script src=\"preboot_browser.js\"></script>\n      <script>\n      document.addEventListener('aurelia-started', function () {\n        // Aurelia has started client-side\n        // but the view/view-model hasn't been loaded yet so we need a small\n        // delay until we can playback all events.\n        setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n      });\n      </script>");
+        var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+        if (html.indexOf("<!-- preboot_script -->") !== -1) {
+            html = html.replace("<!-- preboot_script -->", script);
+        }
+        else {
+            html = utils_1.appendToBody(html, script);
+        }
     }
     return html;
 }

--- a/dist/es2015/aurelia-ssr-engine.js
+++ b/dist/es2015/aurelia-ssr-engine.js
@@ -24,7 +24,7 @@ function render(options, initOptions) {
         .then((ctx) => {
         const document = ctx.pal.DOM.global.document;
         setInputDefaultValues(document.body);
-        const html = transform({ app: ctx.aurelia.host.outerHTML, document }, options);
+        const html = transform({ app: ctx.aurelia.host.innerHTML, document }, options);
         ctx.stop();
         cleanup(options);
         return html;

--- a/dist/es2015/interfaces.d.ts
+++ b/dist/es2015/interfaces.d.ts
@@ -23,6 +23,10 @@ export interface RenderOptions {
      */
     replayDelay?: number;
     /**
+     * When using preboot, where can the preboot script be found
+     */
+    prebootScript?: string;
+    /**
      * Options that are passed to preboot
      */
     prebootOptions?: any;

--- a/dist/es2015/transformers/preboot.js
+++ b/dist/es2015/transformers/preboot.js
@@ -5,6 +5,9 @@ export default function (html, transformerCtx, options) {
         if (options.replayDelay === undefined) {
             options.replayDelay = 10;
         }
+        if (options.prebootScript === undefined) {
+            options.prebootScript = "preboot_browser.js";
+        }
         // preboot catches all events that happens before Aurelia gets loaded client-side
         // so that they can be replayed afterwards
         const prebootOptions = Object.assign({
@@ -26,7 +29,7 @@ export default function (html, transformerCtx, options) {
         const inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = appendToHead(html, `\r\n<script>${inlinePrebootCode}</script>\r\n`);
         // preboot_browser can replay events that were stored by the preboot code
-        const script = `\r\n<script src="preboot_browser.js"></script>
+        const script = `\r\n<script src="${options.prebootScript}"></script>
 <script>
 document.addEventListener('aurelia-started', function () {
   // Aurelia has started client-side

--- a/dist/es2015/transformers/preboot.js
+++ b/dist/es2015/transformers/preboot.js
@@ -26,15 +26,21 @@ export default function (html, transformerCtx, options) {
         const inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = appendToHead(html, `\r\n<script>${inlinePrebootCode}</script>\r\n`);
         // preboot_browser can replay events that were stored by the preboot code
-        html = appendToBody(html, `\r\n<script src="preboot_browser.js"></script>
-      <script>
-      document.addEventListener('aurelia-started', function () {
-        // Aurelia has started client-side
-        // but the view/view-model hasn't been loaded yet so we need a small
-        // delay until we can playback all events.
-        setTimeout(function () { preboot.complete(); }, ${options.replayDelay});
-      });
-      </script>`);
+        const script = `\r\n<script src="preboot_browser.js"></script>
+<script>
+document.addEventListener('aurelia-started', function () {
+  // Aurelia has started client-side
+  // but the view/view-model hasn't been loaded yet so we need a small
+  // delay until we can playback all events.
+  setTimeout(function () { preboot.complete(); }, ${options.replayDelay});
+});
+</script>`;
+        if (html.indexOf("<!-- preboot_script -->") !== -1) {
+            html = html.replace("<!-- preboot_script -->", script);
+        }
+        else {
+            html = appendToBody(html, script);
+        }
     }
     return html;
 }

--- a/dist/native-modules/aurelia-ssr-engine.js
+++ b/dist/native-modules/aurelia-ssr-engine.js
@@ -24,7 +24,7 @@ function render(options, initOptions) {
         .then(function (ctx) {
         var document = ctx.pal.DOM.global.document;
         setInputDefaultValues(document.body);
-        var html = transform({ app: ctx.aurelia.host.outerHTML, document: document }, options);
+        var html = transform({ app: ctx.aurelia.host.innerHTML, document: document }, options);
         ctx.stop();
         cleanup(options);
         return html;

--- a/dist/native-modules/interfaces.d.ts
+++ b/dist/native-modules/interfaces.d.ts
@@ -23,6 +23,10 @@ export interface RenderOptions {
      */
     replayDelay?: number;
     /**
+     * When using preboot, where can the preboot script be found
+     */
+    prebootScript?: string;
+    /**
      * Options that are passed to preboot
      */
     prebootOptions?: any;

--- a/dist/native-modules/transformers/preboot.js
+++ b/dist/native-modules/transformers/preboot.js
@@ -5,6 +5,9 @@ export default function (html, transformerCtx, options) {
         if (options.replayDelay === undefined) {
             options.replayDelay = 10;
         }
+        if (options.prebootScript === undefined) {
+            options.prebootScript = "preboot_browser.js";
+        }
         // preboot catches all events that happens before Aurelia gets loaded client-side
         // so that they can be replayed afterwards
         var prebootOptions = Object.assign({
@@ -26,7 +29,7 @@ export default function (html, transformerCtx, options) {
         var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
         // preboot_browser can replay events that were stored by the preboot code
-        var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+        var script = "\r\n<script src=\"" + options.prebootScript + "\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
         if (html.indexOf("<!-- preboot_script -->") !== -1) {
             html = html.replace("<!-- preboot_script -->", script);
         }

--- a/dist/native-modules/transformers/preboot.js
+++ b/dist/native-modules/transformers/preboot.js
@@ -26,7 +26,13 @@ export default function (html, transformerCtx, options) {
         var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
         html = appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
         // preboot_browser can replay events that were stored by the preboot code
-        html = appendToBody(html, "\r\n<script src=\"preboot_browser.js\"></script>\n      <script>\n      document.addEventListener('aurelia-started', function () {\n        // Aurelia has started client-side\n        // but the view/view-model hasn't been loaded yet so we need a small\n        // delay until we can playback all events.\n        setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n      });\n      </script>");
+        var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+        if (html.indexOf("<!-- preboot_script -->") !== -1) {
+            html = html.replace("<!-- preboot_script -->", script);
+        }
+        else {
+            html = appendToBody(html, script);
+        }
     }
     return html;
 }

--- a/dist/system/aurelia-ssr-engine.js
+++ b/dist/system/aurelia-ssr-engine.js
@@ -1,5 +1,6 @@
 System.register(["./reflect", "./property-descriptor", "./transformers", "./cleanup"], function (exports_1, context_1) {
     "use strict";
+    var transformers_1, cleanup_1;
     var __moduleName = context_1 && context_1.id;
     function render(options, initOptions) {
         if (!options.url) {
@@ -23,7 +24,7 @@ System.register(["./reflect", "./property-descriptor", "./transformers", "./clea
             .then(function (ctx) {
             var document = ctx.pal.DOM.global.document;
             setInputDefaultValues(document.body);
-            var html = transformers_1.transform({ app: ctx.aurelia.host.outerHTML, document: document }, options);
+            var html = transformers_1.transform({ app: ctx.aurelia.host.innerHTML, document: document }, options);
             ctx.stop();
             cleanup_1.cleanup(options);
             return html;
@@ -50,7 +51,6 @@ System.register(["./reflect", "./property-descriptor", "./transformers", "./clea
         PLATFORM.jsdom.reconfigure({ url: requestUrl });
         return start();
     }
-    var transformers_1, cleanup_1;
     return {
         setters: [
             function (_1) {

--- a/dist/system/cleanup.js
+++ b/dist/system/cleanup.js
@@ -1,5 +1,6 @@
 System.register([], function (exports_1, context_1) {
     "use strict";
+    var pop, push, reverse, shift, sort, splice, unshift;
     var __moduleName = context_1 && context_1.id;
     function cleanup(options) {
         // aurelia-binding's array observer overrides the prototype of Array
@@ -37,7 +38,6 @@ System.register([], function (exports_1, context_1) {
             }
         }
     }
-    var pop, push, reverse, shift, sort, splice, unshift;
     return {
         setters: [],
         execute: function () {

--- a/dist/system/interfaces.d.ts
+++ b/dist/system/interfaces.d.ts
@@ -23,6 +23,10 @@ export interface RenderOptions {
      */
     replayDelay?: number;
     /**
+     * When using preboot, where can the preboot script be found
+     */
+    prebootScript?: string;
+    /**
      * Options that are passed to preboot
      */
     prebootOptions?: any;

--- a/dist/system/transformers/index.js
+++ b/dist/system/transformers/index.js
@@ -1,5 +1,6 @@
 System.register([], function (exports_1, context_1) {
     "use strict";
+    var transformers;
     var __moduleName = context_1 && context_1.id;
     // tslint:enable:no-var-requires
     function transform(transformerCtx, options) {
@@ -10,7 +11,6 @@ System.register([], function (exports_1, context_1) {
         return html;
     }
     exports_1("transform", transform);
-    var transformers;
     return {
         setters: [],
         execute: function () {

--- a/dist/system/transformers/preboot.js
+++ b/dist/system/transformers/preboot.js
@@ -7,6 +7,9 @@ System.register(["preboot", "./utils"], function (exports_1, context_1) {
             if (options.replayDelay === undefined) {
                 options.replayDelay = 10;
             }
+            if (options.prebootScript === undefined) {
+                options.prebootScript = "preboot_browser.js";
+            }
             // preboot catches all events that happens before Aurelia gets loaded client-side
             // so that they can be replayed afterwards
             var prebootOptions = Object.assign({
@@ -28,7 +31,7 @@ System.register(["preboot", "./utils"], function (exports_1, context_1) {
             var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
             html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
             // preboot_browser can replay events that were stored by the preboot code
-            var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+            var script = "\r\n<script src=\"" + options.prebootScript + "\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
             if (html.indexOf("<!-- preboot_script -->") !== -1) {
                 html = html.replace("<!-- preboot_script -->", script);
             }

--- a/dist/system/transformers/preboot.js
+++ b/dist/system/transformers/preboot.js
@@ -1,5 +1,6 @@
 System.register(["preboot", "./utils"], function (exports_1, context_1) {
     "use strict";
+    var preboot, utils_1;
     var __moduleName = context_1 && context_1.id;
     function default_1(html, transformerCtx, options) {
         if (options.preboot) {
@@ -27,12 +28,17 @@ System.register(["preboot", "./utils"], function (exports_1, context_1) {
             var inlinePrebootCode = preboot.getInlineCode(prebootOptions);
             html = utils_1.appendToHead(html, "\r\n<script>" + inlinePrebootCode + "</script>\r\n");
             // preboot_browser can replay events that were stored by the preboot code
-            html = utils_1.appendToBody(html, "\r\n<script src=\"preboot_browser.js\"></script>\n      <script>\n      document.addEventListener('aurelia-started', function () {\n        // Aurelia has started client-side\n        // but the view/view-model hasn't been loaded yet so we need a small\n        // delay until we can playback all events.\n        setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n      });\n      </script>");
+            var script = "\r\n<script src=\"preboot_browser.js\"></script>\n<script>\ndocument.addEventListener('aurelia-started', function () {\n  // Aurelia has started client-side\n  // but the view/view-model hasn't been loaded yet so we need a small\n  // delay until we can playback all events.\n  setTimeout(function () { preboot.complete(); }, " + options.replayDelay + ");\n});\n</script>";
+            if (html.indexOf("<!-- preboot_script -->") !== -1) {
+                html = html.replace("<!-- preboot_script -->", script);
+            }
+            else {
+                html = utils_1.appendToBody(html, script);
+            }
         }
         return html;
     }
     exports_1("default", default_1);
-    var preboot, utils_1;
     return {
         setters: [
             function (preboot_1) {

--- a/dist/system/transformers/styles.js
+++ b/dist/system/transformers/styles.js
@@ -1,5 +1,6 @@
 System.register(["./utils"], function (exports_1, context_1) {
     "use strict";
+    var utils_1;
     var __moduleName = context_1 && context_1.id;
     function default_1(html, transformerCtx, options) {
         var headStyleTags = Array.prototype.slice.call(transformerCtx.document.head.querySelectorAll('style'));
@@ -10,7 +11,6 @@ System.register(["./utils"], function (exports_1, context_1) {
         return html;
     }
     exports_1("default", default_1);
-    var utils_1;
     return {
         setters: [
             function (utils_1_1) {

--- a/src/aurelia-ssr-engine.ts
+++ b/src/aurelia-ssr-engine.ts
@@ -32,7 +32,7 @@ function render(options: RenderOptions, initOptions: AppInitializationOptions) {
 
     setInputDefaultValues(document.body as HTMLBodyElement);
 
-    const html = transform({ app: ctx.aurelia.host.outerHTML, document}, options);
+    const html = transform({ app: ctx.aurelia.host.innerHTML, document}, options);
 
     ctx.stop();
     cleanup(options);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,11 @@ export interface RenderOptions {
   replayDelay?: number;
 
   /**
+   * When using preboot, where can the preboot script be found
+   */
+  prebootScript?: string;
+
+  /**
    * Options that are passed to preboot
    */
   prebootOptions?: any;

--- a/src/transformers/preboot.ts
+++ b/src/transformers/preboot.ts
@@ -7,6 +7,9 @@ export default function(html: string, transformerCtx: TransformerContext, option
       if (options.replayDelay === undefined) {
         options.replayDelay = 10;
       }
+      if (options.prebootScript === undefined) {
+        options.prebootScript = "preboot_browser.js";
+      }
 
       // preboot catches all events that happens before Aurelia gets loaded client-side
       // so that they can be replayed afterwards
@@ -30,7 +33,7 @@ export default function(html: string, transformerCtx: TransformerContext, option
       html = appendToHead(html, `\r\n<script>${inlinePrebootCode}</script>\r\n`);
 
       // preboot_browser can replay events that were stored by the preboot code
-      const script = `\r\n<script src="preboot_browser.js"></script>
+      const script = `\r\n<script src="${options.prebootScript}"></script>
 <script>
 document.addEventListener('aurelia-started', function () {
   // Aurelia has started client-side

--- a/src/transformers/preboot.ts
+++ b/src/transformers/preboot.ts
@@ -30,15 +30,20 @@ export default function(html: string, transformerCtx: TransformerContext, option
       html = appendToHead(html, `\r\n<script>${inlinePrebootCode}</script>\r\n`);
 
       // preboot_browser can replay events that were stored by the preboot code
-      html = appendToBody(html, `\r\n<script src="preboot_browser.js"></script>
-      <script>
-      document.addEventListener('aurelia-started', function () {
-        // Aurelia has started client-side
-        // but the view/view-model hasn't been loaded yet so we need a small
-        // delay until we can playback all events.
-        setTimeout(function () { preboot.complete(); }, ${options.replayDelay});
-      });
-      </script>`);
+      const script = `\r\n<script src="preboot_browser.js"></script>
+<script>
+document.addEventListener('aurelia-started', function () {
+  // Aurelia has started client-side
+  // but the view/view-model hasn't been loaded yet so we need a small
+  // delay until we can playback all events.
+  setTimeout(function () { preboot.complete(); }, ${options.replayDelay});
+});
+</script>`;
+      if (html.indexOf("<!-- preboot_script -->") !== -1) {
+        html = html.replace("<!-- preboot_script -->", script)
+      } else {
+        html = appendToBody(html, script)
+      }
   }
 
   return html;


### PR DESCRIPTION
- So that it can play nicely with webpack and doesn't result in nested body tags
- Also allow the preboot_script to be loaded where we want instead of at the end of the html template, which would be after the app has loaded.